### PR TITLE
Fix unit tests to that they run on Telekom's environment.

### DIFF
--- a/test/httpRequestAction.spec.js
+++ b/test/httpRequestAction.spec.js
@@ -1187,7 +1187,10 @@ describe('httpRequest action', () => {
     it('404 not found && dontThrowErrorFlg true', async () => {
       const messagesNewMessageWithBodyStub = stub(messages, 'newMessageWithBody')
         .returns(Promise.resolve());
-      nock.restore();
+      nock('http://example.com')
+        .get('/YourAccount')
+        .delay(20 + Math.random() * 200)
+        .reply(404);
       const method = 'GET';
       const msg = {
         body: {
@@ -1205,13 +1208,17 @@ describe('httpRequest action', () => {
         auth: {},
       };
 
-      await processAction.call(emitter, msg, cfg).then((result) => {
-        console.log();
-      });
+      await processAction.call(emitter, msg, cfg);
       expect(messagesNewMessageWithBodyStub.lastCall.args[0].statusCode).to.eql(404);
-      expect(messagesNewMessageWithBodyStub.lastCall.args[0].statusMessage).to.eql('Not Found');
+      // TODO: should be 'Not Found' but nock doesn't allow statusMessage to be mocked https://github.com/nock/nock/issues/469
+      expect(messagesNewMessageWithBodyStub.lastCall.args[0].statusMessage).to.eql('HTTP error.');
     });
     it('404 not found && dontThrowErrorFlg false', async () => {
+      nock('http://example.com')
+        .get('/YourAccount')
+        .delay(20 + Math.random() * 200)
+        .reply(404);
+
       const method = 'GET';
       const msg = {
         body: {
@@ -1232,7 +1239,8 @@ describe('httpRequest action', () => {
       await processAction.call(emitter, msg, cfg).then((result) => {
         throw new Error('Test case does not expect success response');
       }).catch((e) => {
-        expect(e.message).to.be.eql('Code: 404 Message: Not Found');
+        // TODO: should be 'Code: 404 Message: Not Found' but nock doesn't allow statusMessage to be mocked https://github.com/nock/nock/issues/469
+        expect(e.message).to.be.eql('Code: 404 Message: HTTP error');
       });
     });
   });


### PR DESCRIPTION
The original build was failing on Telekom's infrastructure because it was making actual requests to example.com which is not allowed on Telekom's infrastructure.